### PR TITLE
restclient,resterror: new packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.3
+
+Move rest.Client to new restclient package, and rest.Error to a new resterror
+package. If you would like to remove the 3rd party dependencies like log15 from
+your client code, change imports as follows:
+
+```
+rest.Error => resterror.Error
+rest.NewClient => restclient.New
+rest.Client => restclient.Client
+rest.DefaultTransport => restclient.DefaultTransport
+```
+
+The old imports should still work the same way as before thanks to aliasing.
+
 ## 2.2
 
 Support Bearer authentication.

--- a/compat_test.go
+++ b/compat_test.go
@@ -1,0 +1,10 @@
+package rest
+
+import "testing"
+
+func TestCompat(t *testing.T) {
+	_ = &Error{Title: "foo"}
+	_ = &Client{}
+	d := NewClient("http://base", "user", "pass")
+	d.Client.Transport = DefaultTransport
+}

--- a/rest.go
+++ b/rest.go
@@ -8,6 +8,20 @@ import (
 	"sync"
 
 	log "github.com/inconshreveable/log15"
+	"github.com/kevinburke/rest/restclient"
+	"github.com/kevinburke/rest/resterror"
+)
+
+type (
+	// Backwards compatibility
+	Error     = resterror.Error
+	Client    = restclient.Client
+	Transport = restclient.Transport
+)
+
+var (
+	NewClient        = restclient.New
+	DefaultTransport = restclient.DefaultTransport
 )
 
 const jsonContentType = "application/json; charset=utf-8"
@@ -15,43 +29,10 @@ const jsonContentType = "application/json; charset=utf-8"
 // Logger logs information about incoming requests.
 var Logger log.Logger = log.New()
 
-// Error implements the HTTP Problem spec laid out here:
-// https://tools.ietf.org/html/rfc7807
-type Error struct {
-	// The main error message. Should be short enough to fit in a phone's
-	// alert box. Do not end this message with a period.
-	Title string `json:"title"`
-
-	// Id of this error message ("forbidden", "invalid_parameter", etc)
-	ID string `json:"id"`
-
-	// More information about what went wrong.
-	Detail string `json:"detail,omitempty"`
-
-	// Path to the object that's in error.
-	Instance string `json:"instance,omitempty"`
-
-	// Link to more information about the error (Zendesk, API docs, etc).
-	Type string `json:"type,omitempty"`
-
-	// HTTP status code of the error.
-	Status int `json:"status,omitempty"`
-}
-
-func (e *Error) Error() string {
-	return e.Title
-}
-
-func (e *Error) String() string {
-	if e.Detail != "" {
-		return fmt.Sprintf("rest: %s. %s", e.Title, e.Detail)
-	} else {
-		return fmt.Sprintf("rest: %s", e.Title)
-	}
-}
-
-var handlerMap = make(map[int]http.Handler)
-var handlerMu sync.RWMutex
+var (
+	handlerMap = make(map[int]http.Handler)
+	handlerMu  sync.RWMutex
+)
 
 // RegisterHandler registers the given HandlerFunc to serve HTTP requests for
 // the given status code. Use CtxErr and CtxDomain to retrieve extra values set

--- a/restclient/client.go
+++ b/restclient/client.go
@@ -1,4 +1,4 @@
-package rest
+package restclient
 
 import (
 	"context"
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/kevinburke/rest/resterror"
 )
 
 type UploadType string
@@ -52,9 +54,9 @@ type Client struct {
 	useBearerAuth bool
 }
 
-// NewClient returns a new Client with the given user and password. Base is the
-// scheme+domain to hit for all requests.
-func NewClient(user, pass, base string) *Client {
+// New returns a new Client with HTTP Basic Auth with the given user and
+// password. Base is the scheme+domain to hit for all requests.
+func New(user, pass, base string) *Client {
 	return &Client{
 		ID:          user,
 		Token:       pass,
@@ -196,7 +198,7 @@ func DefaultErrorParser(resp *http.Response) error {
 		return err
 	}
 	defer resp.Body.Close()
-	rerr := new(Error)
+	rerr := new(resterror.Error)
 	err = json.Unmarshal(resBody, rerr)
 	if err != nil {
 		return fmt.Errorf("invalid response body: %s", string(resBody))

--- a/restclient/example_test.go
+++ b/restclient/example_test.go
@@ -1,34 +1,15 @@
-// +build go1.7
-
-package rest_test
+package restclient_test
 
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 
-	"github.com/kevinburke/rest"
 	"github.com/kevinburke/rest/restclient"
 )
-
-func ExampleRegisterHandler() {
-	rest.RegisterHandler(500, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := rest.CtxErr(r)
-		fmt.Println("Server error:", err)
-		w.Header().Set("Content-Type", "text/html")
-		w.WriteHeader(500)
-		w.Write([]byte("<html><body>Server Error</body></html>"))
-	}))
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
-	rest.ServerError(w, req, errors.New("Something bad happened"))
-	// Output: Server error: Something bad happened
-}
 
 func ExampleClient() {
 	client := restclient.New("jobs", "secretpassword", "http://ipinfo.io")
@@ -42,8 +23,8 @@ func ExampleClient() {
 	fmt.Println(r.Ip)
 }
 
-func ExampleNewClient() {
-	client := rest.NewClient("jobs", "secretpassword", "http://ipinfo.io")
+func ExampleNew() {
+	client := restclient.New("jobs", "secretpassword", "http://ipinfo.io")
 	req, _ := client.NewRequest("GET", "/json", nil)
 	type resp struct {
 		City string `json:"city"`
@@ -55,7 +36,7 @@ func ExampleNewClient() {
 }
 
 func ExampleClient_NewRequest() {
-	client := rest.NewClient("jobs", "secretpassword", "http://ipinfo.io")
+	client := restclient.New("jobs", "secretpassword", "http://ipinfo.io")
 	req, _ := client.NewRequest("GET", "/json", nil)
 	type resp struct {
 		City string `json:"city"`
@@ -67,7 +48,7 @@ func ExampleClient_NewRequest() {
 }
 
 func ExampleClient_Do() {
-	client := rest.NewClient("jobs", "secretpassword", "http://ipinfo.io")
+	client := restclient.New("jobs", "secretpassword", "http://ipinfo.io")
 	req, _ := client.NewRequest("GET", "/json", nil)
 	type resp struct {
 		City string `json:"city"`
@@ -85,7 +66,7 @@ func ExampleTransport() {
 	defer server.Close()
 	b := new(bytes.Buffer)
 	client := http.Client{
-		Transport: &rest.Transport{Debug: true, Output: b},
+		Transport: &restclient.Transport{Debug: true, Output: b},
 	}
 	req, _ := http.NewRequest("GET", server.URL+"/bar", nil)
 	client.Do(req)

--- a/restclient/tools_test.go
+++ b/restclient/tools_test.go
@@ -9,7 +9,7 @@
 // we want to modify this file we have to release it publicly, otherwise we're
 // fine.
 
-package rest
+package restclient
 
 import (
 	"fmt"

--- a/restclient/transport.go
+++ b/restclient/transport.go
@@ -1,4 +1,4 @@
-package rest
+package restclient
 
 import (
 	"bytes"

--- a/restclient/transport_test.go
+++ b/restclient/transport_test.go
@@ -1,4 +1,4 @@
-package rest
+package restclient
 
 import (
 	"bytes"
@@ -14,7 +14,7 @@ func TestDebugTransport(t *testing.T) {
 		w.Write([]byte(resp))
 	}))
 	defer s.Close()
-	c := NewClient("foo", "bar", s.URL)
+	c := New("foo", "bar", s.URL)
 	b := new(bytes.Buffer)
 	c.Client.Transport = &Transport{
 		Debug:  true,
@@ -37,7 +37,7 @@ func TestNoDebugTransport(t *testing.T) {
 		w.Write([]byte(resp))
 	}))
 	defer s.Close()
-	c := NewClient("foo", "bar", s.URL)
+	c := New("foo", "bar", s.URL)
 	b := new(bytes.Buffer)
 	c.Client.Transport = &Transport{
 		Debug:  false,

--- a/resterror/resterror.go
+++ b/resterror/resterror.go
@@ -1,0 +1,38 @@
+package resterror
+
+import "fmt"
+
+// Error implements the HTTP Problem spec laid out here:
+// https://tools.ietf.org/html/rfc7807
+type Error struct {
+	// The main error message. Should be short enough to fit in a phone's
+	// alert box. Do not end this message with a period.
+	Title string `json:"title"`
+
+	// Id of this error message ("forbidden", "invalid_parameter", etc)
+	ID string `json:"id"`
+
+	// More information about what went wrong.
+	Detail string `json:"detail,omitempty"`
+
+	// Path to the object that's in error.
+	Instance string `json:"instance,omitempty"`
+
+	// Link to more information about the error (Zendesk, API docs, etc).
+	Type string `json:"type,omitempty"`
+
+	// HTTP status code of the error.
+	Status int `json:"status,omitempty"`
+}
+
+func (e *Error) Error() string {
+	return e.Title
+}
+
+func (e *Error) String() string {
+	if e.Detail != "" {
+		return fmt.Sprintf("rest: %s. %s", e.Title, e.Detail)
+	} else {
+		return fmt.Sprintf("rest: %s", e.Title)
+	}
+}


### PR DESCRIPTION
Right now importing the rest client requires importing all of the
server side dependencies (log15 chief among them), even though they're
unused. Instead pull the client into its own package, and then add
type aliases for backwards compatibility.