### PR TITLE
github: add daily dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Add a Dependabot configuration for the two dependency sources used in
this repository: GitHub Actions and Go modules.

Both update schedules are set to daily, which matches the automation
requirement and avoids the previous case where no Dependabot policy was
configured at all.

