### PR TITLE
restclient: trim devel user-agent versions

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package rest

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -1,3 +1,4 @@
+//go:build go1.7
 // +build go1.7
 
 package rest

--- a/example_test.go
+++ b/example_test.go
@@ -1,5 +1,4 @@
 //go:build go1.7
-// +build go1.7
 
 package rest_test
 

--- a/noctx.go
+++ b/noctx.go
@@ -1,3 +1,4 @@
+//go:build !go1.7
 // +build !go1.7
 
 package rest

--- a/rest_noslog.go
+++ b/rest_noslog.go
@@ -1,5 +1,4 @@
 //go:build !go1.21
-// +build !go1.21
 
 package rest
 

--- a/rest_slog.go
+++ b/rest_slog.go
@@ -1,5 +1,4 @@
 //go:build go1.21
-// +build go1.21
 
 package rest
 

--- a/restclient/client.go
+++ b/restclient/client.go
@@ -28,9 +28,23 @@ const Version = "2.12.0"
 var ua string
 
 func init() {
-	gv := strings.Replace(runtime.Version(), "go", "", 1)
+	gv := normalizedGoVersion(runtime.Version())
 	ua = fmt.Sprintf("rest-client/%s (https://github.com/kevinburke/rest) go/%s (%s/%s)",
 		Version, gv, runtime.GOOS, runtime.GOARCH)
+}
+
+// normalizedGoVersion normalizes typical runtime.Version inputs like
+// "go1.25.1" and "devel go1.27-devel_affadc7997 Wed Apr 1 20:07:33 2026
+// -0700" for use in the User-Agent string.
+func normalizedGoVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if strings.HasPrefix(version, "devel ") {
+		fields := strings.Fields(version)
+		if len(fields) >= 2 {
+			return fields[0] + " " + strings.TrimPrefix(fields[1], "go")
+		}
+	}
+	return strings.TrimPrefix(version, "go")
 }
 
 // Client is a generic Rest client for making HTTP requests.
@@ -182,7 +196,7 @@ func (c *Client) NewRequest(method, path string, body io.Reader) (*http.Request,
 // Unmarshal the response body into v. If the response status code is 400 or
 // above, attempt to Unmarshal the response into an Error. Otherwise return
 // a generic http error.
-func (c *Client) Do(r *http.Request, v interface{}) error {
+func (c *Client) Do(r *http.Request, v any) error {
 	var res *http.Response
 	var err error
 	if c.Client == nil {

--- a/restclient/client_test.go
+++ b/restclient/client_test.go
@@ -18,6 +18,37 @@ import (
 	"github.com/kevinburke/rest/resterror"
 )
 
+func TestNormalizedGoVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "release version",
+			version: "go1.25.1",
+			want:    "1.25.1",
+		},
+		{
+			name:    "development version with timestamp",
+			version: "devel go1.27-devel_affadc7997 Wed Apr 1 20:07:33 2026 -0700",
+			want:    "devel 1.27-devel_affadc7997",
+		},
+		{
+			name:    "development version without extra metadata",
+			version: "devel go1.27-devel_affadc7997",
+			want:    "devel 1.27-devel_affadc7997",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizedGoVersion(tt.version)
+			assertEquals(t, got, tt.want)
+		})
+	}
+}
+
 func TestNilClientNoPanic(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{}"))

--- a/restclient/tools_test.go
+++ b/restclient/tools_test.go
@@ -52,7 +52,7 @@ func assertError(t *testing.T, err error, message string) {
 }
 
 // AssertEquals uses the equality operator (==) to measure one and two
-func assertEquals(t *testing.T, one interface{}, two interface{}) {
+func assertEquals(t *testing.T, one any, two any) {
 	t.Helper()
 	if one != two {
 		t.Fatalf("%s [%v] != [%v]", caller(), one, two)


### PR DESCRIPTION
Normalize runtime versions used in the default User-Agent so\nrelease builds keep the plain Go version and development builds keep\nthe devel marker and commit suffix without the trailing timestamp.\n\nAdd a regression test for release and tip version strings. The required\ngo fix/go fmt/goimports passes also updated a few generated-compatible\nGo syntax details in nearby files.

